### PR TITLE
Lazily load translation units to prevent memory leaks

### DIFF
--- a/src/Echoes.Generator/Generator.cs
+++ b/src/Echoes.Generator/Generator.cs
@@ -141,7 +141,10 @@ public class Generator : IIncrementalGenerator
         // Generate entries for this group
         foreach (var entry in group.Entries.Values.OrderBy(e => e.Key))
         {
-            sb.AppendLine($"{indent}public static TranslationUnit {entry.Key} => new TranslationUnit(_assembly, _file, \"{entry.FullPath}\");");
+            sb.AppendLine(
+                $"{indent}private static readonly Lazy<TranslationUnit> _{entry.Key} = new Lazy<TranslationUnit>(() => new TranslationUnit(_assembly, _file, \"{entry.FullPath}\"));");
+            sb.AppendLine(
+                $"{indent}public static TranslationUnit {entry.Key} => _{entry.Key}.Value;");
         }
 
         // Generate nested classes (sorted for consistent output)


### PR DESCRIPTION
The generator currently generates expression-bodied properties for translation units:

```csharp
public static TranslationUnit Something => new TranslationUnit(...)
```

This results in memory leaks:
- Each property access creates a new `TranslationUnit` instance. Expression bodies with `new` execute on every call.
- Each instance subscribes to `TranslationProvider.OnCultureChanged` in its constructor.
- Subscriptions are never unsubscribed, so `TranslationProvider` holds references to all created instances.
- Garbage collection cannot occur due to these retained references.

This PR fixes this by:
- Creating a backing field for each `TranslationUnit` to ensure only one instance is created per property.
- Using lazy initialization (`Lazy<T>`) so that only accessed translation units are instantiated during the application lifetime.
