### PR TITLE
Refactor Translate class to add parameterless constructor

### DIFF
--- a/src/Echoes.Avalonia/MarkupExtension.cs
+++ b/src/Echoes.Avalonia/MarkupExtension.cs
@@ -6,15 +6,17 @@ namespace Echoes;
 
 public sealed class Translate : MarkupExtension
 {
-     private readonly TranslationUnit _unit;
+    public required TranslationUnit Unit { get; init; }
+
+    public Translate() { }
 
     public Translate(TranslationUnit unit)
     {
-        _unit = unit;
+        Unit = unit;
     }
 
     public override object ProvideValue(IServiceProvider serviceProvider)
     {
-        return _unit.Value.ToBinding();
+        return Unit.Value.ToBinding();
     }
 }

--- a/src/Echoes.SampleApp.Translations/Translations/Strings.toml
+++ b/src/Echoes.SampleApp.Translations/Translations/Strings.toml
@@ -6,6 +6,7 @@ generated_namespace = "Echoes.SampleApp.Translations"
 app_title = "Echoes Sample App"
 welcome = "Welcome to Echoes!"
 greeting = "Hello! This demo shows nested translations and locale fallback."
+cur_culture = "Current Culture: "
 
 # For fallback demonstration
 invariant_only = "This text only exists in English"

--- a/src/Echoes.SampleApp.Translations/Translations/Strings_de.toml
+++ b/src/Echoes.SampleApp.Translations/Translations/Strings_de.toml
@@ -1,6 +1,7 @@
 app_title = "Echoes Beispiel-App"
 welcome = "Willkommen bei Echoes!"
 greeting = "Hallo! Diese Demo zeigt verschachtelte Übersetzungen und Locale-Fallback."
+cur_culture = "aktuelle Kultur: "
 
 # Only in German, not in Austrian
 german_general = "Dieser Text hat eine deutsche Übersetzung, aber keine österreichische Variante"

--- a/src/Echoes.SampleApp.Translations/Translations/Strings_zh.toml
+++ b/src/Echoes.SampleApp.Translations/Translations/Strings_zh.toml
@@ -1,6 +1,7 @@
 app_title = "Echoes 示例应用程序"
 welcome = "欢迎使用 Echoes！"
 greeting = "你好！本示例展示了嵌套翻译与区域设置回退机制。"
+cur_culture = "当前文化："
 
 austrian_specific = "此文本有奥地利、德语和英语版本"
 german_general = "此文本有德语翻译，但没有奥地利变体"

--- a/src/Echoes.SampleApp/MainWindow.axaml
+++ b/src/Echoes.SampleApp/MainWindow.axaml
@@ -37,15 +37,20 @@
               CommandParameter="zh"
               Content="zh"/>
     </UniformGrid>
-    <TextBlock Text="{Binding CurrentCulture, StringFormat='Current Culture: {0}'}"
-               DockPanel.Dock="Bottom"
-               FontStyle="Italic"/>
-    
+    <TextBlock DockPanel.Dock="Bottom" FontStyle="Italic">
+        <TextBlock.Text>
+            <MultiBinding StringFormat="{}{0}{1}">
+                <echoes:Translate Unit="{x:Static translations:Strings.cur_culture}" />
+                <Binding Path="CurrentCulture" />
+            </MultiBinding>
+        </TextBlock.Text>
+    </TextBlock>
+
     <StackPanel>
       <TextBlock Text="{echoes:Translate {x:Static translations:Strings.welcome}}"
                    FontSize="20"
                    FontWeight="Bold"/>
-      
+
       <TextBlock Text="{echoes:Translate {x:Static translations:Strings.greeting}}"
                  FontSize="16"/>
 


### PR DESCRIPTION
Translate class should expose a public parameterless constructor to support xaml object instantiates.